### PR TITLE
FIXED: colorbar in plotTracks.m 

### DIFF
--- a/plotTracks.m
+++ b/plotTracks.m
@@ -464,6 +464,7 @@ else
                                          'FitHeightToText','on');
 
             end
+            colormap jet;
 
           case 3
             %------- highlights longer (in number of frames) branches


### PR DESCRIPTION
Colorbar's colourmap in option typeOfPlot=2 of function plotTracks is now jet, as the line colours for the tracks' velocities. 